### PR TITLE
Fix tuple YAML error

### DIFF
--- a/src/kubespray/cloud.py
+++ b/src/kubespray/cloud.py
@@ -357,7 +357,7 @@ class OpenStack(Cloud):
                            'region_name': self.options['os_region_name'],
                            'network': self.options['network'],
                            'allowed_address_pairs': [{'ip_address': self.options['kube_network']}],
-                           'security_groups': (os_security_group_name,),
+                           'security_groups': [os_security_group_name],
                            'state': 'present'},
                        'with_items': os_instance_names}
                 )
@@ -371,7 +371,7 @@ class OpenStack(Cloud):
                            'key_name': self.options['sshkey'],
                            'region_name': self.options['os_region_name'],
                            'auto_ip': self.options['floating_ip'],
-                           'security_groups': (os_security_group_name,),
+                           'security_groups': [os_security_group_name],
                            'nics': 'port-name={{ item }}',
                            'image': self.options['image']},
                        'register': 'os_%s' % role,


### PR DESCRIPTION
I get the following error message without this change

```
ERROR! Syntax Error while loading YAML.


The error appears to have been in '/Users/user/.kubespray/local.yml': line 9, column 96, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

          ports, os_port: {allowed_address_pairs: [{ip_address: 10.0.0.0/16}], auth: *id001,
          name: '{{item}}', network: default-network, region_name: RegionOne, security_groups: !!python/tuple [
                                                                                               ^ here
We could be wrong, but this one looks like it might be an issue with
missing quotes.  Always quote template expression brackets when they
start a value. For instance:

    with_items:
      - {{ foo }}

Should be written as:

    with_items:
      - "{{ foo }}"
```