### PR TITLE
Add GCE network and subnetwork params 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Example user template template
+### Example user template
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen

--- a/src/kubespray/cloud.py
+++ b/src/kubespray/cloud.py
@@ -227,7 +227,7 @@ class GCE(Cloud):
         # Options list of ansible GCE module
         gce_options = [
             'machine_type', 'image', 'zone', 'service_account_email',
-            'pem_file', 'credentials_file', 'project_id', 'tags'
+            'pem_file', 'credentials_file', 'project_id', 'tags', 'network', 'subnetwork'
         ]
         # Define instance names
         cluster_name = 'k8s-' + get_cluster_name()
@@ -271,8 +271,13 @@ class GCE(Cloud):
                           'content': '{{gce_%s.instance_data}}' % role}}
                 )
                 # Wait for ssh task
+                if self.options['use_private_ip']:
+                    instance_ip = '{{ item.private_ip }}'
+                else:
+                    instance_ip = '{{ item.public_ip }}'
+
                 self.pbook_content[0]['tasks'].append(
-                    {'local_action': {'host': '{{ item.public_ip }}',
+                    {'local_action': {'host': '%s' % instance_ip,
                                       'module': 'wait_for',
                                       'port': 22,
                                       'state': 'started',

--- a/src/kubespray/files/kubespray.yml
+++ b/src/kubespray/files/kubespray.yml
@@ -61,7 +61,9 @@ loglevel: "info"
 # sshkey: "<os_ssh_key_name>"
 #
 # All the options to be passed to the 'ansible-playbook' command line
+# Note: 'serial=1' ansible option is a workaround for bug https://github.com/ansible/ansible/issues/17935 which causes installation to hang due to SSH multiplexing
 # ansible-opts:
+#   - 'serial=1'
 #   - '-vvv'
 #   - '-e'
 #   - 'myvar1=bar'

--- a/src/kubespray/files/kubespray.yml
+++ b/src/kubespray/files/kubespray.yml
@@ -24,6 +24,7 @@ loglevel: "info"
 # security_group_name: "<security_group_name>"
 # security_group_id: "<security_group_id>"
 # assign_public_ip: True
+# use_private_ip: true
 # vpc_subnet_id: "<vpc_id>"
 # region: "<aws_region>"
 # tags:
@@ -38,6 +39,9 @@ loglevel: "info"
 # service_account_email: "<gce_service_account_email>"
 # pem_file: "<gce_pem_file>"
 # project_id: "<gce_project_id>"
+# network: "<gce_network_name>"
+# subnetwork: "<gce_subnetwork_name>"
+# use_private_ip: true
 # zone: "<cloud_region>"
 # tags:
 #   - k8s


### PR DESCRIPTION
Allow the user to choose network & subnetwork that cluster VMs will use.
Add the option to use private IP for Ansible SSH connections on GCE (Same as in AWS).