### PR TITLE
Update Ansible requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Example on GCE:
 Requirements
 ============
 
--   **Ansible v2.x**
+-   **Ansible v2.3 (or newer)**
 -   The current user must have its ssh **public key** installed on the
     remote servers.
 -   The remote user (option --user) must be in the sudoers with no


### PR DESCRIPTION
The Kubespray required Ansible v2.3+ is installed on the machine. In order to ensure that the installation will not fail, I update README requirements section to prompt user.