### PR TITLE
Failed to auth when kubespray try to create openstack vms

### DIFF
--- a/src/kubespray/cloud.py
+++ b/src/kubespray/cloud.py
@@ -305,7 +305,7 @@ class OpenStack(Cloud):
             openstack_auth.update({cred_arg: self.options['os_%s' % cred_arg]})
 
         if 'os_domain_name' in self.options:
-            openstack_auth.update({'domain_name': self.options[os_domain_name]})
+            openstack_auth.update({'domain_name': self.options['os_domain_name']})
 
         if self.options['floating_ip']:
             ip_type = 'public'


### PR DESCRIPTION
When using kubespray with cloud provider openstack, I just found a tiny
issue, but will block the process of creating OpenStack VMs. OpenStack
domain will not set due to python syntax issue. This issue will block
when using OpenStack provider with keytsont v3 authentication.