### PR TITLE
[kubespray-cli] Fix the Ansible variable so the correct plays execute

### DIFF
--- a/src/kubespray/deploy.py
+++ b/src/kubespray/deploy.py
@@ -217,7 +217,7 @@ class RunPlaybook(object):
             cmd = cmd + ['-e', 'bootstrap_os=coreos']
         elif 'redhat' in self.options.keys() and self.options['redhat']:
             cmd = cmd + [
-                '-e', 'bootstrap_os=redhat', '-e', 'ansible_os_family=RedHat'
+                '-e', 'bootstrap_os=centos', '-e', 'ansible_os_family=RedHat'
             ]
         elif 'ubuntu' in self.options.keys() and self.options['ubuntu']:
             cmd = cmd + ['-e', 'bootstrap_os=ubuntu']


### PR DESCRIPTION
The Ansible variable `bootstrap_os` is set incorrectly to redhat. This is not a valid option, and consequently the required plays do not get executed: https://github.com/kubernetes-incubator/kubespray/blob/65a9772adfc8ae7d463c9b3cbc87a5dcd1dc1791/inventory/group_vars/all.yml#L2

```RUNNING HANDLER [kubernetes/master : Master | wait for the apiserver to be running] ******************************************************************************************************************************************************************************************
Wednesday 30 August 2017  17:25:14 +0100 (0:00:00.504)       0:26:15.606 ******
FAILED - RETRYING: Master | wait for the apiserver to be running (20 retries left).
ok: [node1]```

