### PR TITLE
Fix issue about setting customized cluster name when using kubespray

### DIFF
--- a/src/kubespray/cloud.py
+++ b/src/kubespray/cloud.py
@@ -314,6 +314,8 @@ class OpenStack(Cloud):
 
         # Define instance names
         cluster_name = 'k8s-' + get_cluster_name()
+        if 'cluster_name' in self.options.keys():
+            cluster_name = 'k8s-' + self.options['cluster_name']
         os_security_group_name = cluster_name + '-%s' % id_generator()
 
         self.pbook_content[0]['tasks'].append(
@@ -348,11 +350,6 @@ class OpenStack(Cloud):
                         os_instance_names.append(
                             cluster_name + '-%s' % id_generator()
                         )
-                    elif 'cluster_name' in self.options.keys():
-                        os_instance_names.append(
-                            self.options['cluster_name'] + '-%s' % id_generator()
-                        )
-                        os_security_group_name = self.options['cluster_name'] + '-%s' % id_generator()
                     else:
                         os_instance_names.append(
                             cluster_name + '-%s' % id_generator()


### PR DESCRIPTION
openstack

When using `kubespray openstack` to initialize environment and deploy
kubernetes cluster, if you want to setup a cluster name with
`--cluster-name`, you will always receive errors like 

```
TASK [Create nodes network ports]
**********************************************
failed: [localhost] (item=k8s-phenomenal-ootp8f) => {"failed": true,
"item": "k8s-phenomenal-ootp8f", "msg": "Security group:
k8s-phenomenal-69k17f, was not found"}
failed: [localhost] (item=k8s-phenomenal-ystmto) => {"failed": true,
"item": "k8s-phenomenal-ystmto", "msg": "Security group:
k8s-phenomenal-69k17f, was not found"}
failed: [localhost] (item=k8s-phenomenal-k2f8sf) => {"failed": true,
"item": "k8s-phenomenal-k2f8sf", "msg": "Security group:
k8s-phenomenal-69k17f, was not found"}
```

That is because security group name is redefined and security group is
not created with these names. 

These is one issue existing,
https://github.com/kubespray/kubespray-cli/issues/64

I did some code changes, which cluster_name will be changed at the first
place when customer set a new one.

Please help to review and let me know if anything that I could update or
improve.