### PR TITLE
Use kubespray reset to quickly remove the kubernetes environment.

### DIFF
--- a/bin/kubespray
+++ b/bin/kubespray
@@ -29,6 +29,7 @@ from kubespray.common import clone_kubespray_git_repo
 from kubespray.configure import Config
 from kubespray.inventory import CfgInventory
 from kubespray.deploy import RunPlaybook
+from kubespray.reset import RunResetPlaybook
 from kubespray.cloud import AWS, GCE, OpenStack
 display = Display()
 
@@ -42,6 +43,10 @@ def prepare(options):
         options['etcds_list']
     )
 
+def reset(options):
+    RunReset = RunResetPlaybook(options)
+    RunReset.ssh_prepare()
+    RunReset.reset_kubernetes()
 
 def aws(options):
     clone_kubespray_git_repo(options)
@@ -405,6 +410,39 @@ if __name__ == '__main__':
         help='Ansible options'
     )
     deploy_parser.set_defaults(func=deploy)
+
+
+    # reset
+    reset_parser = subparsers.add_parser(
+    'reset', parents=[parent_parser],
+    help='reset generate inventory'
+    )
+    reset_parser.add_argument(
+        '--verbose', default=False, action='store_true',
+        help="Run Ansible playbook in verbose mode '-vvvv'"
+    )
+    reset_parser.add_argument(
+        '-k', '--sshkey', dest='ssh_key',
+        help='ssh key for authentication on remote servers'
+    )
+    reset_parser.add_argument(
+        '-K', '--ask-become-pass', default=False, action='store_true', dest='ask_become_pass',
+        help='ask for privilege escalation password'
+    )
+    reset_parser.add_argument(
+        '-u', '--user', dest='ansible_user', default=getpass.getuser(),
+        help='Ansible SSH user (remote user)'
+    )
+    reset_parser.add_argument(
+        '--coreos', default=False, action='store_true',
+        help='bootstrap python on CoreOS'
+    )
+    reset_parser.add_argument(
+        '--ansible-opts', dest='ansible_opts',
+        help='Ansible options'
+    )
+    reset_parser.set_defaults(func=reset)
+
 
     # Parse arguments
     args = parser.parse_args()

--- a/src/kubespray/reset.py
+++ b/src/kubespray/reset.py
@@ -1,0 +1,156 @@
+import re
+import sys
+import os
+import yaml
+import signal
+import netaddr
+from subprocess import PIPE, STDOUT, Popen, check_output, CalledProcessError
+from kubespray.common import get_logger, query_yes_no, run_command, which, validate_cidr
+from ansible.utils.display import Display
+display = Display()
+playbook_exec = which('ansible-playbook')
+ansible_exec = which('ansible')
+
+class RunResetPlaybook(object):
+    '''
+    Run the Ansible playbook to reset the kubernetes cluster
+    '''
+    def __init__(self, options):
+        self.existing_ssh_agent = False
+        self.options = options
+        self.inventorycfg = options['inventory_path']
+        self.logger = get_logger(
+            options.get('logfile'),
+            options.get('loglevel')
+        )
+        self.logger.debug(
+            'Running ansible-playbook command with the following options: %s'
+            % self.options
+        )
+
+    def kill_ssh_agent(self):
+        if self.existing_ssh_agent:
+            return
+
+        if 'SSH_AGENT_PID' in os.environ:
+            agent_pid = os.environ.get('SSH_AGENT_PID')
+
+            if agent_pid.isdigit():
+                os.kill(int(agent_pid), signal.SIGTERM)
+
+    def ssh_prepare(self):
+        '''
+        Run ssh-agent and store identities
+        '''
+
+        if 'SSH_AUTH_SOCK' in os.environ:
+            self.existing_ssh_agent = True
+            self.logger.info('Using existing ssh agent')
+            return
+
+        try:
+            sshagent = check_output('ssh-agent')
+        except CalledProcessError as e:
+            display.error('Cannot run the ssh-agent : %s' % e.output)
+        # Set environment variables
+        ssh_envars = re.findall('\w*=[\w*-\/.*]*', sshagent)
+        for v in ssh_envars:
+            os.environ[v.split('=')[0]] = v.split('=')[1]
+        # Store ssh identity
+        try:
+            if 'ssh_key' in self.options.keys():
+                cmd = ['ssh-add', os.path.realpath(self.options['ssh_key'])]
+            else:
+                cmd = 'ssh-add'
+            proc = Popen(
+                cmd, stdout=PIPE, stderr=STDOUT, stdin=PIPE
+            )
+            proc.stdin.write('password\n')
+            proc.stdin.flush()
+            response_stdout, response_stderr = proc.communicate()
+            display.display(response_stdout)
+        except CalledProcessError as e:
+            display.error('Failed to store ssh identity : %s' % e.output)
+            sys.exit(1)
+        except IOError:
+            display.error('Could not find SSH key. Have you run ssh-keygen?')
+        try:
+            check_output(['ssh-add', '-l'])
+        except CalledProcessError as e:
+            display.error('Failed to list identities : %s' % e.output)
+            sys.exit(1)
+        if response_stderr:
+            display.error(response_stderr)
+            self.logger.critical(
+                'Deployment stopped because of ssh credentials'
+                % self.filename
+            )
+            self.kill_ssh_agent()
+            sys.exit(1)
+
+    def check_ping(self):
+        '''
+         Check if hosts are reachable
+        '''
+        display.banner('CHECKING SSH CONNECTIONS')
+        cmd = [
+            ansible_exec, '--ssh-extra-args', '-o StrictHostKeyChecking=no',
+            '-u', '%s' % self.options['ansible_user'],
+            '-b', '--become-user=root', '-m', 'ping', 'all',
+            '-i', self.inventorycfg
+        ]
+        if 'sshkey' in self.options.keys():
+            cmd = cmd + ['--private-key', self.options['sshkey']]
+        if self.options['ask_become_pass']:
+            cmd = cmd + ['--ask-become-pass']
+        if self.options['coreos']:
+            cmd = cmd + ['-e', 'ansible_python_interpreter=/opt/bin/python']
+        display.display(' '.join(cmd))
+        rcode, emsg = run_command('SSH ping hosts', cmd)
+        if rcode != 0:
+            self.logger.critical('Cannot connect to hosts: %s' % emsg)
+            self.kill_ssh_agent()
+            sys.exit(1)
+        display.display('All hosts are reachable', color='green')
+
+    def reset_kubernetes(self):
+        '''
+        Run reset the ansible playbook command
+        '''
+        cmd = [
+            playbook_exec, '--ssh-extra-args', '-o StrictHostKeyChecking=no',
+            '-u',  '%s' % self.options['ansible_user'],
+            '-b', '--become-user=root', '-i', self.inventorycfg,
+            os.path.join(self.options['kubespray_path'], 'reset.yml')
+        ]
+        # Ansible verbose mode
+        if 'verbose' in self.options.keys() and self.options['verbose']:
+            cmd = cmd + ['-vvvv']
+        # Add privilege escalation password
+        if self.options['ask_become_pass']:
+            cmd = cmd + ['--ask-become-pass']
+        # Add any additionnal Ansible option
+        if 'ansible_opts' in self.options.keys():
+            cmd = cmd + self.options['ansible_opts'].split(' ')
+        self.check_ping()
+
+        if not self.options['assume_yes']:
+            if not query_yes_no(
+                'Reset kubernetes cluster with the above command ?'
+            ):
+                apply=no
+                display.display('Aborted', color='red')
+                sys.exit(1)
+        display.banner('RUN Reset PLAYBOOK')
+        cmd = cmd + ['--extra-vars','reset_confirmation=yes']
+        self.logger.info(
+            'Running kubernetes reset with the command: %s' % ' '.join(cmd)
+        )
+        cmd = cmd + ['--extra-vars','reset_confirmation=yes']
+        rcode, emsg = run_command('Reset deployment', cmd)
+        if rcode != 0:
+            self.logger.critical('Reset failed: %s' % emsg)
+            self.kill_ssh_agent()
+            sys.exit(1)
+        display.display('Kubernetes Reset successfuly', color='green')
+        self.kill_ssh_agent()


### PR DESCRIPTION
So I modified bin / kubespray, added reset related programs.
Added reset.py as the module for reset.

I tested in my cluster, five nodes which are three master nodes and two worker nodes.
The test environment is ubuntu 16.04 & Kubernetes v1.7.3+coreos.0

At the same time I have another test environment

three nodes which are one master nodes and two worker nodes.
The test environment is centos7 & Kubernetes v1.7.3+coreos.0