### PR TITLE
default config file path should be user's home

### DIFF
--- a/bin/kubespray
+++ b/bin/kubespray
@@ -100,7 +100,7 @@ if __name__ == '__main__':
     )
     parent_parser.add_argument(
         '--config', dest='configfile',
-        help="Config file path. Defaults to /etc/kubespray/kubespray.yml"
+        help="Config file path. Defaults to ~/.kubespray.yml"
     )
     parent_parser.add_argument(
         '-y', '--assumeyes', default=False, dest='assume_yes', action='store_true',


### PR DESCRIPTION
Default config file path (where kubespray.yml) should be user's home dir, not /etc/kubespray/.

```python
    if args.configfile is None:
        default_config_dir = os.path.expanduser("~")
        if not os.path.isdir(default_config_dir):
            os.makedirs(default_config_dir)
        args.configfile = os.path.join(default_config_dir, ".kubespray.yml")
```