### PR TITLE
Corrected url for kubespray repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ frequently </br>
     # Defaults to current user's home directory if not set
     # kubespray_path: "/tmp"
     # Default inventory path
-    kubespray_git_repo: "https://github.com/kubespray/kubespray.git"
+    kubespray_git_repo: "https://github.com/kubernetes-incubator/kubespray.git"
     # Logging options
     loglevel: "info"
 


### PR DESCRIPTION
after a bit of confusion, I solved this and would like to prevent others in the future running into the [same issue.](https://github.com/kubespray/kubespray-cli/issues/113)