### PR TITLE
License typo in every source header: Foobar to Kubespray

### DIFF
--- a/bin/kubespray
+++ b/bin/kubespray
@@ -8,13 +8,13 @@
 #    the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
 #
-#    Foobar is distributed in the hope that it will be useful,
+#    Kubespray is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #    GNU General Public License for more details.
 #
 #    You should have received a copy of the GNU General Public License
-#    along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+#    along with Kubespray.  If not, see <http://www.gnu.org/licenses/>.
 
 __version__ = '0.5.2'
 

--- a/src/kubespray/cloud.py
+++ b/src/kubespray/cloud.py
@@ -8,13 +8,13 @@
 #    the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
 #
-#    Foobar is distributed in the hope that it will be useful,
+#    Kubespray is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #    GNU General Public License for more details.
 #
 #    You should have received a copy of the GNU General Public License
-#    along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+#    along with Kubespray.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 kubespray.cloud

--- a/src/kubespray/common.py
+++ b/src/kubespray/common.py
@@ -3,18 +3,18 @@
 #
 # This file is part of Kubespray.
 #
-#    Foobar is free software: you can redistribute it and/or modify
+#    Kubespray is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
 #
-#    Foobar is distributed in the hope that it will be useful,
+#    Kubespray is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #    GNU General Public License for more details.
 #
 #    You should have received a copy of the GNU General Public License
-#    along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+#    along with Kubespray.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
 import shutil

--- a/src/kubespray/configure.py
+++ b/src/kubespray/configure.py
@@ -14,7 +14,7 @@
 #    GNU General Public License for more details.
 #
 #    You should have received a copy of the GNU General Public License
-#    along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+#    along with Kubespray.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 kubespray.configure

--- a/src/kubespray/deploy.py
+++ b/src/kubespray/deploy.py
@@ -3,18 +3,18 @@
 #
 # This file is part of Kubespray.
 #
-#    Foobar is free software: you can redistribute it and/or modify
+#    Kubespray is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
 #
-#    Foobar is distributed in the hope that it will be useful,
+#    Kubespray is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #    GNU General Public License for more details.
 #
 #    You should have received a copy of the GNU General Public License
-#    along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+#    along with Kubespray.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 kubespray.deploy

--- a/src/kubespray/inventory.py
+++ b/src/kubespray/inventory.py
@@ -8,13 +8,13 @@
 #    the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
 #
-#    Foobar is distributed in the hope that it will be useful,
+#    Kubespray is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #    GNU General Public License for more details.
 #
 #    You should have received a copy of the GNU General Public License
-#    along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+#    along with Kubespray.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 kubespray.inventory


### PR DESCRIPTION
Probably just missed due to copy&paste